### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 MCP Server for the GitHub API, enabling file operations, repository management, search functionality, and more.
 
+<a href="https://glama.ai/mcp/servers/bnif4b1rh6"><img width="380" height="200" src="https://glama.ai/mcp/servers/bnif4b1rh6/badge" alt="GitHub Server MCP server" /></a>
+
 ### Features
 
 - **Automatic Branch Creation**: When creating/updating files or pushing changes, branches are automatically created if they don't exist


### PR DESCRIPTION
This PR adds a badge for the [GitHub MCP Server](https://glama.ai/mcp/servers/bnif4b1rh6) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/bnif4b1rh6"><img width="380" height="200" src="https://glama.ai/mcp/servers/bnif4b1rh6/badge" alt="GitHub Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added an image badge link to the README file for the GitHub MCP Server
	- Included an anchor tag with a specific URL and image display details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->